### PR TITLE
[x64] Delimit all POST logging with \r\n\r\n

### DIFF
--- a/dist/script/lib/debug.js
+++ b/dist/script/lib/debug.js
@@ -39,7 +39,7 @@ XenClient.UI.Debug = (function() {
 
                 XUIXhr.post(
                     "/log/0",
-                    "UI: " + message,
+                    "UI: " + message + "\r\n\r\n",
                     null,
                     null,
                     {


### PR DESCRIPTION
Quark server expects payload to end in two newlines.
Delimit all POST requests so that the server can parse
them properly.

Signed-off-by: Nicholas Tsirakis <tsirakisn@ainfosec.com>